### PR TITLE
Fix bugs and improve robustness

### DIFF
--- a/WavFile.php
+++ b/WavFile.php
@@ -126,7 +126,7 @@ class WavFile
     /** @var int Starting offset of data chunk */
     protected $_dataOffset;
 
-    /** @var array Array of samples */
+    /** @var string Binary string of samples */
     protected $_samples;
 
     /** @var int Number of sample blocks */
@@ -456,7 +456,7 @@ class WavFile
         // RIFF header
         $header = pack('N', 0x52494646); // ChunkID - "RIFF"
 
-        $subchunk1size = $this->getAudioFormat() == self::WAVE_FORMAT_PCM ? 16 : 18; // 16 bytes for PCM, else +2 bytes for extension length
+        $subchunk1size = $this->getAudioFormat() == self::WAVE_FORMAT_PCM ? 16 : 18; // 16 bytes for PCM, else +2 bytes for extension size
         $subchunk2size = $this->getDataSize();
 
         $header .= pack('V', 4 + (8 + $subchunk1size) + (8 +  $subchunk2size)); // ChunkSize
@@ -1209,7 +1209,7 @@ class WavFile
                      substr($header, 12, 26));
 
         if ($fmt['SubChunk1ID'] != 0x666d7420) {
-            throw new WavFormatException('Bad wav header, expected "fmt", found "' . $fmt['SubChunk1ID'] . '".', 6);
+            throw new WavFormatException('Bad wav header, expected "fmt ", found "' . $fmt['SubChunk1ID'] . '".', 6);
         }
 
         $this->setSubChunk1Size($fmt['SubChunk1Size'], false);


### PR DESCRIPTION
I had some more time:
Fixed two bugs.
Improved support for 32-bit floats to be more compliant with the standard (see http://www-mmsp.ece.mcgill.ca/documents/audioformats/wave/wave.html).
24-bits still need revision as they do not play in MediaPlayer - will tackle that soon.
Minor speed improvement.
Overall improvement in robustness.

There are two more commits after this pull request. Please have a look at the 2nd. I think it is a good idea to give the user a choice in what normalization method is used. A default value of sth. like 0.5 to 0.6 gives best results imho - remember that with logarithmic compression, lower values are not as bad, as the compression factor only gradually increases.

And I think there could be an issue with your default value checking in the constructor of securimage. For comparison is_null() should be used instead of == null. For example, a boolean value would == null for false as well (audio_use_noise, degrade_audio).
