### PR TITLE
Allow Ajax verification BEFORE a second after POST verification

### DIFF
--- a/securimage.php
+++ b/securimage.php
@@ -683,6 +683,7 @@ class Securimage
     /**
      * Check a submitted code against the stored value
      * @param string $code  The captcha code to check
+     * @param bool $noclear Do not clear image (use with ajax)
      * <code>
      * $code = $_POST['code'];
      * $img  = new Securimage();
@@ -693,10 +694,10 @@ class Securimage
      * }
      * </code>
      */
-    public function check($code)
+    public function check($code, $noclear = false)
     {
         $this->code_entered = $code;
-        $this->validate();
+        $this->validate($noclear);
         return $this->correct_code;
     }
 
@@ -1341,8 +1342,9 @@ class Securimage
     /**
      * Checks the entered code against the value stored in the session or sqlite database, handles case sensitivity
      * Also clears the stored codes if the code was entered correctly to prevent re-use
+     * @param bool $noclear Do not clear image (use with ajax)
      */
-    protected function validate()
+    protected function validate($noclear = false)
     {
         if (!is_string($this->code) || strlen($this->code) == 0) {
             $code = $this->getCode();
@@ -1366,6 +1368,8 @@ class Securimage
         if ($code != '') {
             if ($code == $code_entered) {
                 $this->correct_code = true;
+                if ($noclear){ return; }
+                
                 if ($this->no_session != true) {
                     $_SESSION['securimage_code_value'][$this->namespace] = '';
                     $_SESSION['securimage_code_ctime'][$this->namespace] = '';


### PR DESCRIPTION
Users were unable to type in the catpcha, so I added an ajax feature to validate it after they type it (securimage didnt support this) So I just added a $noclear parameter so that it wouldn't clear the session or database while validating 

->check($mycaptcha, true);   //will not clear the session or database and allow submitting afterwards