### PR TITLE
Exclude some dirs and files from repository auto-generated ZIP archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/examples/ export-ignore
+/captcha.html export-ignore
+/config.inc.php.SAMPLE export-ignore
+/example_form.ajax.php export-ignore
+/example_form.php export-ignore


### PR DESCRIPTION
People that install this library via composer don't need the examples, they just need the library itself.
This PR removes the sample directories and files from the repository auto-generated ZIP archives.
Developers that need some more info can still do a `git clone` or just look at this repo on GitHub.