### PR TITLE
.htaccess files Apache 2.4 compatibility update

### DIFF
--- a/audio/.htaccess
+++ b/audio/.htaccess
@@ -1,1 +1,11 @@
-deny from all
+# Deny access to this folder
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+	Require all denied
+</IfModule>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+	Deny from all
+</IfModule>

--- a/database/.htaccess
+++ b/database/.htaccess
@@ -1,1 +1,11 @@
-deny from all
+# Deny access to this folder
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+	Require all denied
+</IfModule>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+	Deny from all
+</IfModule>


### PR DESCRIPTION
The .htaccess files used to restrict access to specific directories
follow the Apache 2.2 mod_authz_host module syntax [1] (Order, Allow,
Deny).

Apache 2.4 introduced a new module mod_authz_core [2], with a different,
incompatible directive (Require). Consequently, unless the compatibility
module access_compat is enabled, the obsolete ones will cause Apache
configuration errors to occur when the .htaccess file is read.

To avoid this, the .htaccess files are modified to use the new syntax
when an Apache 2.4 server is detected, and fall back to the old
directives otherwise.

[1] https://httpd.apache.org/docs/2.2/mod/mod_authz_host.html
[2] https://httpd.apache.org/docs/2.4/mod/mod_authz_core.html